### PR TITLE
Fix missing deps and improve readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,21 @@ CFPB's internal chat bot built on [Hubot](http://hubot.github.com).
 
 ## Installation
 
+### Install Node.js
+
+1. `curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.25.2/install.sh | bash`
+1. `nvm install 0.10`
+1. `nvm use 0.10`
+
+### Install CFPBot
+
 1. `git clone https://github.com/cfpb/CFPBot.git`
 1. `cd CFPBot`
 1. `cp .env.sample .env`
 1. Edit `.env` appropriately.
-1. `curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.25.2/install.sh | bash`
-1. `nvm install 0.10`
-1. `nvm use 0.10`
+
+### Running CFPBot
+
 1. `npm i -g forever`
 1. `forever -c /bin/sh ./start.sh`
 
@@ -36,9 +44,12 @@ You can test your hubot by running the following, however some plugins will not
 behave as expected unless the [environment variables](#configuration) they rely
 upon have been set.
 
-You can start CFPBot locally by running:
+You can start CFPBot locally by following the "Install CFPBot" steps above
+followed by:
 
-    % bin/hubot
+```
+$ ./bin/hubot
+```
 
 You'll see some start up output and a prompt:
 

--- a/external-scripts.json
+++ b/external-scripts.json
@@ -1,4 +1,5 @@
 [
   "hubot-google-hangouts",
-  "hubot-twitter-search"
+  "hubot-twitter-search",
+  "hubot-ambush"
 ]

--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -11,7 +11,6 @@
   "eardropping.coffee",
   "remind.coffee",
   "reload.coffee",
-  "ambush.coffee",
   "applause.coffee",
   "excuse.coffee",
   "janky.coffee",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "author": "CFPB <tech@cfpb.gov>",
   "description": "CFPB's chat bot",
   "dependencies": {
+    "chrono-node": "^1.0.6",
     "hubot": "^2.12.0",
+    "hubot-ambush": "0.0.3",
     "hubot-diagnostics": "0.0.1",
     "hubot-google-hangouts": "^0.7.1",
     "hubot-google-images": "^0.1.4",
@@ -21,6 +23,8 @@
     "hubot-twitter-search": "^1.0.3",
     "hubot-xmpp": "^0.1.12",
     "hubot-youtube": "^0.1.2",
+    "lodash": "^3.9.3",
+    "moment": "^2.10.3",
     "underscore": "^1.8.3"
   },
   "engines": {


### PR DESCRIPTION
Fixes #3. It turns out you have to manually add hubot-scripts deps to your package.json.

I also improved installation docs and moved `hubot-ambush` to external-scripts because the author moved it to its own repo.