### PR TITLE
Updated Matteruser to work with 3.0 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "hubot-jira-lookup": "git://github.com/jivesoftware/hubot-jira-lookup.git#840ff7444479324fbdb423c1c7f7630b4c886f5d",
     "hubot-keys": "^2.0.0",
     "hubot-maps": "0.0.2",
-    "hubot-matteruser": "contolini/hubot-matteruser#v1",
+    "hubot-matteruser": "^3.1.0",
     "hubot-murder": "^1.0.0",
     "hubot-plusplus": "1.2.5",
     "hubot-pugme": "0.1.0",


### PR DESCRIPTION
Previous version of this used to point to contolini/hubot-matteruser#v1 - this represents a change and points us back to the source repo / tagged version. I was not able to see any specific changes to the v1 fork so this should work as billed.