### PR TITLE
Remove google hangouts hubot plugin

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -1,6 +1,5 @@
 [
   "hubot-acrogov",
-  "hubot-google-hangouts",
   "hubot-google-images",
   "hubot-guys",
   "hubot-jira-lookup",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "hubot-eavesdrop": "^2.0.0",
     "hubot-github-identity": "0.10.0",
     "hubot-github-management": "^2.0.0",
-    "hubot-google-hangouts": "0.7.1",
     "hubot-google-images": "0.2.6",
     "hubot-google-translate": "0.2.0",
     "hubot-guys": "0.0.1",


### PR DESCRIPTION
Remove google hangouts hubot plugin

Hangouts is no longer a product, and thus this plugin no longer works.