### PR TITLE
Remove hubot-thankfulness

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -21,7 +21,6 @@
   "hubot-newrelic2-cfpb",
   "mattermost-slashbot",
   "hubot-lgtm",
-  "hubot-thankfulness",
   "hubot-reload-scripts",
   "hubot-cfpb-indexer"
 ]

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "hubot-spotify-meta": "^1.0.0",
     "hubot-squads": "^2.0.0",
     "hubot-standup-alarm": "0.1.0",
-    "hubot-thankfulness": "1.0.1",
     "hubot-twitter-search": "1.0.3",
     "hubot-youtube": "1.0.2",
     "lodash": "4.17.12",


### PR DESCRIPTION
This PR removes the [hubot-thankfulness](https://www.npmjs.com/package/hubot-thankfulness) plugin, added back in #43.

See internal DEVPLAT-1528 for context.